### PR TITLE
Disable ICU Breakiterator for Khmer

### DIFF
--- a/i18npool/qa/cppunit/test_breakiterator.cxx
+++ b/i18npool/qa/cppunit/test_breakiterator.cxx
@@ -44,7 +44,6 @@ public:
 #ifdef TODO
     void testNorthernThai();
 #endif
-    void testKhmer();
     void testJapanese();
     void testChinese();
 
@@ -60,9 +59,6 @@ public:
 #endif
 #ifdef TODO
     CPPUNIT_TEST(testNorthernThai);
-#endif
-#if (U_ICU_VERSION_MAJOR_NUM > 4)
-    CPPUNIT_TEST(testKhmer);
 #endif
     CPPUNIT_TEST(testJapanese);
     CPPUNIT_TEST(testChinese);
@@ -888,33 +884,6 @@ void TestBreakIterator::testNorthernThai()
         i18n::WordType::DICTIONARY_WORD, true);
     CPPUNIT_ASSERT_MESSAGE("Should skip full word",
         aBounds.startPos == 0 && aBounds.endPos == aTest.getLength());
-}
-#endif
-
-#if (U_ICU_VERSION_MAJOR_NUM > 4)
-// Not sure if any version earlier than 49 did have Khmer word boundary
-// dictionaries, 4.6 does not.
-
-//A test to ensure that our khmer word boundary detection is useful
-//https://bugs.libreoffice.org/show_bug.cgi?id=52020
-void TestBreakIterator::testKhmer()
-{
-    lang::Locale aLocale;
-    aLocale.Language = "km";
-    aLocale.Country = "KH";
-
-    const sal_Unicode KHMER[] = { 0x17B2, 0x17D2, 0x1799, 0x1782, 0x17C1 };
-
-    OUString aTest(KHMER, SAL_N_ELEMENTS(KHMER));
-    i18n::Boundary aBounds = m_xBreak->getWordBoundary(aTest, 0, aLocale,
-        i18n::WordType::DICTIONARY_WORD, true);
-
-    CPPUNIT_ASSERT(aBounds.startPos == 0 && aBounds.endPos == 3);
-
-    aBounds = m_xBreak->getWordBoundary(aTest, aBounds.endPos, aLocale,
-        i18n::WordType::DICTIONARY_WORD, true);
-
-    CPPUNIT_ASSERT(aBounds.startPos == 3 && aBounds.endPos == 5);
 }
 #endif
 

--- a/i18npool/source/breakiterator/breakiterator_unicode.cxx
+++ b/i18npool/source/breakiterator/breakiterator_unicode.cxx
@@ -123,8 +123,8 @@ void SAL_CALL BreakIterator_Unicode::loadICUBreakIterator(const com::sun::star::
                 rbi = new OOoRuleBasedBreakIterator(udata_open("OpenOffice", "brk",
                     OUStringToOString(breakRules[breakType], RTL_TEXTENCODING_ASCII_US).getStr(), &status), status);
             }
-            //use icu's breakiterator for Thai, Khmer, Tibetan and Dzongkha
-            else if (rLocale.Language != "th" && rLocale.Language != "lo" && rLocale.Language != "km" && rLocale.Language != "bo" && rLocale.Language != "dz")
+            //use icu's breakiterator for Thai, Tibetan and Dzongkha
+            else if (rLocale.Language != "th" && rLocale.Language != "lo" && rLocale.Language != "bo" && rLocale.Language != "dz")
             {
                 status = U_ZERO_ERROR;
                 OStringBuffer aUDName(64);


### PR DESCRIPTION
Enabling the ICU Breakiterator causes Khmer spelling checkers to be worthless as well as wrecks havoc on various minority languages that use the Khmer script. See this https://bugs.documentfoundation.org/show_bug.cgi?id=52020
this: https://bugs.freedesktop.org/show_bug.cgi?id=59448
and this: https://bugs.documentfoundation.org/show_bug.cgi?id=59447&redirected_from=fdo
It would be great if this change would be reflected in the master branch, but I am doing this personally for my own build to release on sbbic.org since it has been years without resolution and many Khmer users and minority language users have been unable to use LibreOffice because of this. LibreOffice is miles beyond OpenOffice now, and I would rather use LibreOffice.