### PR TITLE
Correct the error

### DIFF
--- a/cli_ure/source/uno_bridge/cli_bridge.cxx
+++ b/cli_ure/source/uno_bridge/cli_bridge.cxx
@@ -131,9 +131,10 @@ void SAL_CALL Mapping_uno2cli(
             if(cliI)
             {
                 ptr= sri::GCHandle::ToIntPtr(sri::GCHandle::Alloc(cliI))
-#ifdef _WIN32
+#ifdef _WIN64
+                    .ToInt64();
+#else /* defined(_WIN32) */
                     .ToInt32();
-#else /* defined(_WIN64) */                 .ToInt64();
 #endif
             }
             (*ppOut)= reinterpret_cast<void*>(ptr);


### PR DESCRIPTION
Always _WIN32 is defined, even in Win64. So the check must be to _WIN64 and then to _WIN32.
Hope no more lines like this in code.
Can you test programs with SDK 64 Bit?