### PR TITLE
Fix building against MySQL Connector/C 8

### DIFF
--- a/connectivity/source/drivers/mysqlc/mysqlc_preparedstatement.hxx
+++ b/connectivity/source/drivers/mysqlc/mysqlc_preparedstatement.hxx
@@ -39,11 +39,17 @@ using ::com::sun::star::uno::Reference;
 using ::com::sun::star::uno::RuntimeException;
 using ::com::sun::star::uno::Type;
 
+#if defined MYSQL_VERSION_ID && (MYSQL_VERSION_ID >= 80000)
+using my_bool = bool;
+#else
+using my_bool = char;
+#endif
+
 struct BindMetaData
 {
-    char is_null = 0;
+    my_bool is_null = 0;
     unsigned long length = 0;
-    char error = 0;
+    my_bool error = 0;
 };
 
 typedef ::cppu::ImplHelper5<css::sdbc::XPreparedStatement, css::sdbc::XParameters,


### PR DESCRIPTION
In MySQL Connector/C 8, `my_bool` is replaced by `bool`.  It was previously defined as `char`.  When building against MySQL Connector/C 8, this leads to errors such as:
```
var/tmp/portage/app-office/libreoffice-6.3.0.4/work/libreoffice-6.3.0.4/connectivity/source/drivers/mysqlc/mysqlc_prepared_resultset.cxx: In member function ‘virtual sal_Bool connectivity::mysqlc::OPreparedResultSet::next()’:
/var/tmp/portage/app-office/libreoffice-6.3.0.4/work/libreoffice-6.3.0.4/connectivity/source/drivers/mysqlc/mysqlc_prepared_resultset.cxx:635:30: error: cannot convert ‘char*’ to ‘bool*’ in assignment
  635 |         m_aData[i].is_null = &m_aMetaData[i].is_null;
      |                              ^~~~~~~~~~~~~~~~~~~~~~~
      |                              |
      |                              char*
/var/tmp/portage/app-office/libreoffice-6.3.0.4/work/libreoffice-6.3.0.4/connectivity/source/drivers/mysqlc/mysqlc_prepared_resultset.cxx:638:28: error: cannot convert ‘char*’ to ‘bool*’ in assignment
  638 |         m_aData[i].error = &m_aMetaData[i].error;
      |                            ^~~~~~~~~~~~~~~~~~~~~
      |                            |
      |                            char*
make[1]: *** [/var/tmp/portage/app-office/libreoffice-6.3.0.4/work/libreoffice-6.3.0.4/solenv/gbuild/LinkTarget.mk:293: /var/tmp/portage/app-office/libreoffice-6.3.0.4/work/libreoffice-6.3.0.4/workdir/CxxObject/connectivity/source/drivers/mysqlc/mysqlc_prepared_resultset.o] Error 1
```
This commit fixes that error by redefining affected members of `struct BindMetaData` as `bool` if using version 8 of greater.  Otherwise, they default to `char`.