### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/source/AndroidManifest.xml
+++ b/android/source/AndroidManifest.xml
@@ -133,7 +133,11 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".LibreOfficeMainActivity" />
         </activity>
-
+        
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
+        
         <provider
             android:name="android.support.v4.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"


### PR DESCRIPTION
On Android Marshmallow, Google has completely removed the support of Apache HTTP client because it doesn't have good performance compared to the alternatives.

This might also be the cause for so many apps crashing on Android Marshmallow.

So it will reduce crashes in newer versions