### PR TITLE
shebang

### DIFF
--- a/setup_native/scripts/osx_install_languagepack.applescript
+++ b/setup_native/scripts/osx_install_languagepack.applescript
@@ -1,3 +1,5 @@
+#!/usr/bin/osascript
+
 (*
 
  This file is part of the LibreOffice project.


### PR DESCRIPTION
use this AppleScript script as the App’s executable instead of the currently used bash script which invokes the AppleScript script.