### PR TITLE
Removed entry "fx." from DocumentList.xml (Danish) that can make valid syntax invalid

### DIFF
--- a/extras/source/autocorr/lang/da/DocumentList.xml
+++ b/extras/source/autocorr/lang/da/DocumentList.xml
@@ -223,7 +223,7 @@
   <block-list:block block-list:abbreviated-name="fungere gerne" block-list:name="fungerer gerne"/>
   <block-list:block block-list:abbreviated-name="fungere ikke" block-list:name="fungerer ikke"/>
   <block-list:block block-list:abbreviated-name="fungere ofte" block-list:name="fungerer ofte"/>
-  <block-list:block block-list:abbreviated-name="fx." block-list:name="fx"/>
+  <!-- Please don't add replacement of "fx." to "fx", as "fx." is perfectly valid at the end of a sentence. -->
   <block-list:block block-list:abbreviated-name="gallionsfigur" block-list:name="galionsfigur"/>
   <block-list:block block-list:abbreviated-name="gemmen" block-list:name="gennem"/>
   <block-list:block block-list:abbreviated-name="genenm" block-list:name="gennem"/>


### PR DESCRIPTION
The replacement of "fx." to "fx" is not thought through; it can change a valid sentence into an invalid one. 

It was clearly originally added because "fx." looks like a simple misspelling of the abbreviation "fx". (Normally abbreviations in Danish end in a ".", but there are a few exceptions such as this.) So the simple original thought behind the rule is to always replace "fx." with "fx" to correct a common misspelling.

But since it is perfectly valid for "fx" to be placed in the end of a sentence, right before the full stop ("."), resulting in the correct character sequence "fx.", this rule will often change correct syntax with incorrect (I have often experienced exactly this, prompting me to finally do something about it). An example full and absolutely correct Danish sentence including "fx." could be "Vi kunne jo tage bussen, fx.". Because of this replacement rule, the full stop at the end of the sentence is removed, resulting in an incorrect sentence without full stop at the end. 

It is fine to replace obvious mistakes that are always mistakes (that's what this list is partly about), but we should never replace sequences of characters that can be in fact be perfectly valid and correct in normal writing. And "fx." is a case of that.

Therefore this rule should be removed. 

I also added a comment to explain why it shouldn't be added again, if someone gets the original simple thought again without thinking it through. I assume the XML reader is a full-blown XML reader that can handle XML comments. Also, a single comment like this only affects performance absolutely minimally.