### PR TITLE
fix Neg Select

### DIFF
--- a/sc/source/core/data/markmulti.cxx
+++ b/sc/source/core/data/markmulti.cxx
@@ -231,7 +231,7 @@ void ScMultiSel::SetMarkArea( SCCOL nStartCol, SCCOL nEndCol, SCROW nStartRow, S
                 nLast = aRowSel.GetMarkEnd( nBeg, false );
         }
 
-        if ( nBeg != mrSheetLimits.GetMaxRowCount() && nLast >= nEndRow )
+        if ( nBeg != mrSheetLimits.GetMaxRowCount() && nLast >= nEndRow && nBeg <= nEndRow )
             MarkAllCols( nBeg, nEndRow );
         else
         {
@@ -242,7 +242,7 @@ void ScMultiSel::SetMarkArea( SCCOL nStartCol, SCCOL nEndCol, SCROW nStartRow, S
                 if ( nBeg != mrSheetLimits.GetMaxRowCount() )
                     nLast = aRowSel.GetMarkEnd( nBeg, false );
             }
-            if ( nBeg != mrSheetLimits.GetMaxRowCount() && nLast >= nEndRow )
+            if ( nBeg != mrSheetLimits.GetMaxRowCount() && nLast >= nEndRow && nBeg <= nEndRow )
                 MarkAllCols( nBeg, nEndRow );
         }
 


### PR DESCRIPTION
In Calc Select all and neg select . There is a BUG 
![视频1 h264](https://user-images.githubusercontent.com/33484052/165431574-81632d0f-a106-4d64-bb99-6876065504f3.gif)

The reason is in `ScMultiSel::SetMarkArea` that case will make `nBeg` bigger than `nEndRow` and in `MarkAllCols`  start will bigger than end
so I add determine to make sure that when `nBeg` bigger than `nEndRow` 
