### PR TITLE
Convert a Multi-Page Text/word file to PNG using LibreOffice API in JAVA 

### DIFF
--- a/Help.md
+++ b/Help.md
@@ -1,0 +1,22 @@
+How to convert a Multi-Page Text file to PNG, for example:- I have a Text document of 5 pages and I want to convert that into PNG. By default, it's giving a PNG of only 1st page. How to get the PNG file for ith page using LibreOffice.
+
+I used the PageRange filter like this, but it does not work, it's also giving the PNG only for 1st page.
+
+Also, I'm not able to generate multiple PNGs for multi-page word files using the LibreOffice Application
+
+CLI:-
+```
+soffice --convert-to 'png:writer_png_Export:{"PageRange":{"type":"string","value":"2-"}}' test.odt
+```
+
+JAVA:
+
+```java
+conversionProperties[0] = new com.sun.star.beans.PropertyValue();
+conversionProperties[0].Name = "FilterName";
+conversionProperties[0].Value ="writer_png_Export";
+
+conversionProperties[1] = new com.sun.star.beans.PropertyValue();
+conversionProperties[1].Name = "PageRange";
+conversionProperties[1].Value ="2-";
+```


### PR DESCRIPTION
How to convert a Multi-Page Text file to PNG, for example:- I have a Text document of 5 pages and I want to convert that into PNG. By default, it's giving a PNG of only 1st page. How to get the PNG file for ith page using LibreOffice.

I used the PageRange filter like this, but it does not work, it's also giving the PNG only for 1st page.

Also, I'm not able to generate multiple PNGs for multi-page word files using the LibreOffice Application

CLI:-
```
soffice --convert-to 'png:writer_png_Export:{"PageRange":{"type":"string","value":"2-"}}' test.odt
```

JAVA:-

```java
conversionProperties[0] = new com.sun.star.beans.PropertyValue();
conversionProperties[0].Name = "FilterName";
conversionProperties[0].Value ="writer_png_Export";

conversionProperties[1] = new com.sun.star.beans.PropertyValue();
conversionProperties[1].Name = "PageRange";
conversionProperties[1].Value ="2-";
```

cc: @stbergmann @vmiklos @caolanm @mmohrhard

 
